### PR TITLE
[sairedis] Change static variable to use smart pointers instead of raw pointers

### DIFF
--- a/syncd/ServiceMethodTable.cpp
+++ b/syncd/ServiceMethodTable.cpp
@@ -71,7 +71,7 @@ template<class B, template<size_t> class D, size_t... i>
 static constexpr auto declare_static(std::index_sequence<i...>)
 {
     SWSS_LOG_ENTER();
-    return std::array<B*, sizeof...(i)>{{new D<i>()...}};
+    return std::array<std::shared_ptr<B>, sizeof...(i)>{{std::make_shared<D<i>>()...}};
 }
 
 template<class B, template<size_t> class D, size_t size>
@@ -79,10 +79,10 @@ static constexpr auto declare_static()
 {
     SWSS_LOG_ENTER();
     auto arr = declare_static<B,D>(std::make_index_sequence<size>{});
-    return std::vector<B*>{arr.begin(), arr.end()};
+    return std::vector<std::shared_ptr<B>>{arr.begin(), arr.end()};
 }
 
-std::vector<ServiceMethodTable::SlotBase*> ServiceMethodTable::m_slots =
+std::vector<std::shared_ptr<ServiceMethodTable::SlotBase>> ServiceMethodTable::m_slots =
     declare_static<ServiceMethodTable::SlotBase, ServiceMethodTable::Slot, 10>();
 
 #pragma GCC diagnostic pop

--- a/syncd/ServiceMethodTable.h
+++ b/syncd/ServiceMethodTable.h
@@ -89,7 +89,7 @@ namespace syncd
                 }
         };
 
-            static std::vector<SlotBase*> m_slots;
+            static std::vector<std::shared_ptr<SlotBase>> m_slots;
 
         public:
 
@@ -109,6 +109,6 @@ namespace syncd
 
         private:
 
-            SlotBase*m_slot;
+            std::shared_ptr<SlotBase> m_slot;
     };
 }

--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -120,7 +120,7 @@ template<class B, template<size_t> class D, size_t... i>
 static constexpr auto declare_static(std::index_sequence<i...>)
 {
     SWSS_LOG_ENTER();
-    return std::array<B*, sizeof...(i)>{{new D<i>()...}};
+    return std::array<std::shared_ptr<B>, sizeof...(i)>{{std::make_shared<D<i>>()...}};
 }
 
 template<class B, template<size_t> class D, size_t size>
@@ -128,10 +128,10 @@ static constexpr auto declare_static()
 {
     SWSS_LOG_ENTER();
     auto arr = declare_static<B,D>(std::make_index_sequence<size>{});
-    return std::vector<B*>{arr.begin(), arr.end()};
+    return std::vector<std::shared_ptr<B>>{arr.begin(), arr.end()};
 }
 
-std::vector<SwitchNotifications::SlotBase*> SwitchNotifications::m_slots =
+std::vector<std::shared_ptr<SwitchNotifications::SlotBase>> SwitchNotifications::m_slots =
     declare_static<SwitchNotifications::SlotBase, SwitchNotifications::Slot, 0x10>();
 
 #pragma GCC diagnostic pop

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -163,7 +163,7 @@ namespace syncd
                 }
         };
 
-            static std::vector<SwitchNotifications::SlotBase*> m_slots;
+            static std::vector<std::shared_ptr<SwitchNotifications::SlotBase>> m_slots;
 
         public:
 
@@ -187,6 +187,6 @@ namespace syncd
 
         private:
 
-            SlotBase*m_slot;
+            std::shared_ptr<SlotBase> m_slot;
     };
 }


### PR DESCRIPTION
#### Why I did it
To fix a memory issue.

#### How I did it
Used smart pointers in order for memory to be released when not being referenced anymore.

#### How to verify it
Run auto negotiation interfaces tests. 
On 202205 latest,  the following leaks occur, after the fix issue not reproduced.

```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7f5076865647 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55a6717aad43 in declare_static<syncd::SwitchNotifications::SlotBase, syncd::SwitchNotifications::Slot, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15> syncd/SwitchNotifications.cpp:113
    #2 0x55a6717aad43 in declare_static<syncd::SwitchNotifications::SlotBase, syncd::SwitchNotifications::Slot, 16> syncd/SwitchNotifications.cpp:120
    #3 0x55a6717aad43 in __static_initialization_and_destruction_0 syncd/SwitchNotifications.cpp:124
    #4 0x55a6717aad43 in _GLOBAL__sub_I_SwitchNotifications.cpp syncd/SwitchNotifications.cpp:160

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f5076865647 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55a6717aa680 in declare_static<syncd::ServiceMethodTable::SlotBase, syncd::ServiceMethodTable::Slot, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9> syncd/ServiceMethodTable.cpp:74
    #2 0x55a6717aa680 in declare_static<syncd::ServiceMethodTable::SlotBase, syncd::ServiceMethodTable::Slot, 10> syncd/ServiceMethodTable.cpp:81
    #3 0x55a6717aa680 in __static_initialization_and_destruction_0 syncd/ServiceMethodTable.cpp:85
    #4 0x55a6717aa680 in _GLOBAL__sub_I_ServiceMethodTable.cpp syncd/ServiceMethodTable.cpp:121
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
